### PR TITLE
Fixed the expireUrl API call before the time expires.

### DIFF
--- a/src/components/banktransfer/Bank.jsx
+++ b/src/components/banktransfer/Bank.jsx
@@ -5,7 +5,7 @@ import { RiFileCopyFill } from "react-icons/ri";
 import { copyToClipboard } from '../../utils';
 import "./Bank.css"
 
-const Bank = ({ ac_name, ac_no, bank_name, ifsc, amount, formattedTime }) => {
+const Bank = ({ ac_name, ac_no, bank_name, ifsc, amount }) => {
 
 
   return (
@@ -14,7 +14,7 @@ const Bank = ({ ac_name, ac_no, bank_name, ifsc, amount, formattedTime }) => {
         <p className='text'>Payment Time Left</p>
         <div className="right-area">
           <MdOutlineTimer size={20} color='white' />
-          <p className='timer-text'>00:{formattedTime}</p>
+          <p className='timer-text' id='bank-timer'>00:10:00</p>
         </div>
       </div>
       <div className="section-container">

--- a/src/components/upi/Upi.jsx
+++ b/src/components/upi/Upi.jsx
@@ -6,14 +6,14 @@ import { QrGenerator } from '../qr-generator'
 import { copyToClipboard } from '../../utils';
 import "./Upi.css";
 
-const Upi = ({ code, amount, upi_id,formattedTime,ac_name }) => {
+const Upi = ({ code, amount, upi_id,ac_name }) => {
   return (
     <section className='upi-section' >
       <div className="bank-container" >
         <p className='text'>Payment Time Left</p>
         <div className="right-area">
           <MdOutlineTimer size={20} color='white' />
-          <p className='timer-text'>00:{formattedTime}</p>
+          <p className='timer-text' id='upi-timer'>00:10:00</p>
         </div>
       </div>
       <div className="section-container">

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -38,6 +38,6 @@ export const processTransaction = async (token, data) => {
     return await APIParser(http.post(`/process/${token}`, data));
 }
 
-export const payInExpireURL = async (token) => {
-    return await APIParser(http.post(`/expire-url/${token}`));
+export const payInOneTimeExpireURL = async (token) => {
+    return await APIParser(http.post(`/expire-one-time-payin-url/${token}`));
 }


### PR DESCRIPTION
I've made some changes in expire timing flow due to some reason. As we were not saving the actual `UNIX `in database. We were dividing it by `1000`.

## Bug Explanation:
In code we have two types of expiry check.
1. If timer went 0 or below.
2. If current timestamp is greater than the expiry timer stamp received from server.

Due to timer un-consistency we were having more than 200 seconds difference. So, the second check was throwing the Expire URL call that's why payment was going to `DROPPED`. Other than this bug the API calls were also in a kind of callback hell it was just being called once Transaction is expired.


## Implemented Solution:
1. Removed the timer `useStates `and reduced the `useEffect` dependency on timer.
2. Keep the timer code  simple and in one function.
4. Fixed the double validateToken API call.
5. Instead of dividing the timestamp by `1000` I've multiplied the `expireTime` with 1000 that received from server so we can reduce second difference.

## Other Changes:
1. I've renamed the API Path and function of oneTimeExpireUrl for better naming convention.


### `Need Review. Please have a look and if anything seems off give me feedback.`