### PR TITLE
 Removed the assigning of bank in check payment status handler

### DIFF
--- a/src/screens/transactions/Transactions.jsx
+++ b/src/screens/transactions/Transactions.jsx
@@ -8,7 +8,7 @@ import "./transactions.css";
 import ModelPopUp from "../../components/modelPopup/ModelPopUp";
 import WebSockets from "../../components/webSockets/WebSockets";
 import { ErrorImg } from "../../utils/constants";
-import { payInExpireURL } from "../../services/user";
+
 
 const Transactions = () => {
   const params = useParams();

--- a/src/screens/transactions/Transactions.jsx
+++ b/src/screens/transactions/Transactions.jsx
@@ -77,7 +77,7 @@ const Transactions = () => {
       const data = {
         amount: res?.data?.data?.amount,
       }
-      handleAmount(data);
+      // handleAmount(data);
     }
     else {
       setIsModalOpen(true);

--- a/src/screens/transactions/Transactions.jsx
+++ b/src/screens/transactions/Transactions.jsx
@@ -72,16 +72,17 @@ const Transactions = () => {
         });
       }, 10000);
     }
-    if (res?.data?.data?.amount !== 0) {
-      setIsModalOpen(false);
-      const data = {
-        amount: res?.data?.data?.amount,
-      }
-      // handleAmount(data);
-    }
-    else {
-      setIsModalOpen(true);
-    }
+    // if (res?.data?.data?.amount !== 0) {
+    //   setIsModalOpen(false);
+    //   const data = {
+    //     amount: res?.data?.data?.amount,
+    //   }
+    //   // handleAmount(data);
+    // }
+    // else {
+    //   setIsModalOpen(true);
+    // }
+    setIsModalOpen(true);
   };
 
   useEffect(() => {

--- a/src/screens/transactions/Transactions.jsx
+++ b/src/screens/transactions/Transactions.jsx
@@ -8,10 +8,12 @@ import "./transactions.css";
 import ModelPopUp from "../../components/modelPopup/ModelPopUp";
 import WebSockets from "../../components/webSockets/WebSockets";
 import { ErrorImg } from "../../utils/constants";
+import { useLocation } from 'react-router-dom';
 
 
 const Transactions = () => {
   const params = useParams();
+  const location = useLocation();
   const [loading, setLoading] = useState(true);
   const [amountLoading, setAmountLoading] = useState(false);
   const [processing, setProcessing] = useState(false);
@@ -27,6 +29,9 @@ const Transactions = () => {
   const isQr = !transactionsInformation || transactionsInformation.is_qr;
   const isBank = !transactionsInformation || transactionsInformation.is_bank;
   const [showTrustPayModal, setShowTrustPayModal] = useState(false);
+
+  const queryParams = new URLSearchParams(location.search);
+  const isTestMode = queryParams.get('t');
 
   useEffect(() => {
     handleExpireURL(params.token);
@@ -161,7 +166,7 @@ const Transactions = () => {
       expireUrlHandler();
       return;
     } else {
-      setShowTrustPayModal(true);
+      isTestMode && setShowTrustPayModal(true);
     }
     const bankData = res?.data?.data || null;
     setTransactionInformation(bankData);
@@ -414,7 +419,7 @@ const Transactions = () => {
                     </div>
                   </Form>
                 </Modal>
-                <Modal
+                {isTestMode && <Modal
                   title={
                     <div className="absolute inset-x-0 top-0 text-center text-2xl text-white bg-black py-6" style={{ width: '100%', zIndex: 1 }}>
                       Welcome to Trust Pay
@@ -429,7 +434,7 @@ const Transactions = () => {
                       <Button
                         key="Test Success"
                         type="primary"
-                        onClick={() => handleTestResult('SUCCESS')}
+                        onClick={() => handleTestResult('TEST_SUCCESS')}
                         className="bg-green-600 border-green-600 text-white w-80 h-12 text-lg"
                       >
                         Test Success
@@ -437,7 +442,7 @@ const Transactions = () => {
                       <Button
                         key="Test Failure"
                         type="primary"
-                        onClick={() => handleTestResult('DROPPED')}
+                        onClick={() => handleTestResult('TEST_DROPPED')}
                         className="bg-red-600 border-red-600 text-white w-80 h-12 text-lg"
                       >
                         Test Failure
@@ -462,7 +467,7 @@ const Transactions = () => {
                     boxShadow: 'none'
                   }}
                 >
-                </Modal>
+                </Modal>}
               </div>
             </>
           )}

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -33,6 +33,10 @@ export const imageSubmit = async (token, data, amount) => {
     return res
 }
 
+export const testResult = async (token, data) => {
+    return await APIParser(http.post(`/update-payment-status/${token}`,data));
+}
+
 
 export const processTransaction = async (token, data) => {
     return await APIParser(http.post(`/process/${token}`, data));

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
+
 export default defineConfig({
   plugins: [react()],
-})
+  build: {
+    outDir: 'dist',
+  },
+});


### PR DESCRIPTION
## Added Feature:

- Added the Test Modal for `SUCCESS` or `FAILURE` case if query string have `t=true`.
     - Test modal will appear after entering the amount.
     - Test mode has its own statuses `TEST_SUCCESS` and `TEST_DROPPED`.


## Bug Explanation:

When user make transaction `SUCCESS` from admin panel but it was still `ASSIGNED`. That's because the function socket is handling has some logic about amount of transaction that was assigning the bank to transaction. And in this flow transaction again turned back to `ASSIGNED`.

## Implemented Solution:

- Just commented the function for now to not re-assign the bank. In this way transaction status stays `SUCCESS`.

## Other Changes:

- Re Added the Timer Expiry Re factored flow.
- Added tab or window focus listener, In case if timer is running slowly if user changes tab or window this listener will helps to re-evaluate the seconds difference.